### PR TITLE
Force set `TIGERBEETLE_RELEASE` env var for sys crate

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -83,6 +83,7 @@ fn main() {
                 .canonicalize()
                 .unwrap(),
         )
+        .env("TIGERBEETLE_RELEASE", "0.15.3")
         .arg("build")
         .arg("c_client")
         .args((!debug).then_some("-Drelease"))


### PR DESCRIPTION
For whatever reason, the way tigerbeetle is being built for the sys crate doesn't set the `release` build option. This is the root cause for #15.

This makes it so that we apply that build option.

fixes #15

